### PR TITLE
Builds fail on Linux (case sensitivity on path names)

### DIFF
--- a/Arduino/libraries/RBL_BLEMini/ble_mini.cpp
+++ b/Arduino/libraries/RBL_BLEMini/ble_mini.cpp
@@ -1,5 +1,5 @@
 
-#include "ble_Mini.h"
+#include "ble_mini.h"
 
 // UNO 
 // TX: pin 1

--- a/Arduino/libraries/RBL_BLEMini/examples/BLEFirmataSketch/BLEFirmata.cpp
+++ b/Arduino/libraries/RBL_BLEMini/examples/BLEFirmataSketch/BLEFirmata.cpp
@@ -14,7 +14,7 @@
 //* Includes
 //******************************************************************************
 
-#include "BleFirmata.h"
+#include "BLEFirmata.h"
 #include "HardwareSerial.h"
 #include "ble_mini.h"
 


### PR DESCRIPTION
Building the Firmata example exposed a few issues with building the examples on Linux.

I've changed the includes in ble_mini.cpp and BLEFirmata.cpp to correctly refer to ble_mini.h and BLEFirmata.h - they seemed to assume an OS that was case-insensitive.
